### PR TITLE
Use Paths from java.nio for better OS support and path resolution

### DIFF
--- a/src/main/java/io/forcesoftware/Main.java
+++ b/src/main/java/io/forcesoftware/Main.java
@@ -7,6 +7,11 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 
 @Getter
 public class Main {
@@ -14,15 +19,33 @@ public class Main {
     public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     public static final Logger LOGGER = LogManager.getLogger("io.forcesoftware.Main");
 
-    public static String configPath;
+    public static Path configPath;
 
     public static void main(String[] args) {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            configPath = System.getenv("AppData") + "/spbot";
-        } else if (SystemUtils.IS_OS_MAC) {
-            configPath = System.getProperty("user.home") + "/Library/Application Support/spbot";
-        }
-
+        setConfigurationPath();
+        createConfigurationDirectory();
         new ShoePalaceBot();
     }
+
+    public static void setConfigurationPath() {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            configPath = Paths.get(System.getenv("AppData"), "spbot");
+        } else if (SystemUtils.IS_OS_MAC) {
+            configPath = Paths.get(System.getProperty("user.home"), "Library", "Application Support", "spbot");
+        } else if (SystemUtils.IS_OS_LINUX) {
+            // Create a hidden directory in the user's home directory on Linux
+            configPath = Paths.get(System.getProperty("user.home"), ".spbot");
+        }
+    }
+
+    public static void createConfigurationDirectory() {
+        if (!Files.exists(configPath)) {
+            try {
+                Files.createDirectory(configPath);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
 }

--- a/src/main/java/io/forcesoftware/loaders/Loader.java
+++ b/src/main/java/io/forcesoftware/loaders/Loader.java
@@ -17,7 +17,7 @@ public abstract class Loader {
     public abstract String getFileName();
 
     protected void loadFile(String defaultContents) {
-        file = new File(Main.configPath + "/" + getFileName());
+        file = new File(Main.configPath + File.separator + getFileName());
 
         if (!file.exists()) {
             try {


### PR DESCRIPTION
This PR adds support for Linux and gets rid of the hard-coded path separators instead opting for using the Paths class for handling this.

Also fixes the issue where the configuration directory must be created before the application is ran. 